### PR TITLE
Implement network filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ cargo run --release --config 'target."cfg(all())".runner="sudo -E"'
 Cargo build scripts are used to automatically build the eBPF correctly and include it in the
 program.
 
+### Filtering configuration
+
+The eBPF program uses block and allow lists to decide whether to drop or permit
+packets. Set the `BLOCK_LIST` or `ALLOW_LIST` environment variables to a
+comma‑separated list of IPv4 addresses. The block list may also contain domain
+names, which are resolved when the loader starts.
+
+Example:
+
+```bash
+BLOCK_LIST="example.com,93.184.216.34" \
+ALLOW_LIST="1.2.3.4" \
+cargo run --release --config 'target."cfg(all())".runner="sudo -E"'
+```
+
 ## Cross-compiling on macOS
 
 Cross compilation should work on both Intel and Apple Silicon Macs.

--- a/bee-trace-common/src/lib.rs
+++ b/bee-trace-common/src/lib.rs
@@ -1,1 +1,18 @@
 #![no_std]
+
+/// Map name storing blocked IPv4 addresses.
+pub const BLOCK_LIST: &str = "BLOCK_LIST";
+
+/// Map name storing explicitly allowed IPv4 addresses.
+pub const ALLOW_LIST: &str = "ALLOW_LIST";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn const_values() {
+        assert_eq!(BLOCK_LIST, "BLOCK_LIST");
+        assert_eq!(ALLOW_LIST, "ALLOW_LIST");
+    }
+}

--- a/bee-trace-ebpf/Cargo.toml
+++ b/bee-trace-ebpf/Cargo.toml
@@ -15,3 +15,4 @@ which = { workspace = true }
 [[bin]]
 name = "bee-trace"
 path = "src/main.rs"
+test = false

--- a/bee-trace-ebpf/src/lib.rs
+++ b/bee-trace-ebpf/src/lib.rs
@@ -1,3 +1,14 @@
 #![no_std]
 
 // This file exists to enable the library target.
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn sanity() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/bee-trace-ebpf/src/main.rs
+++ b/bee-trace-ebpf/src/main.rs
@@ -1,11 +1,42 @@
 #![no_std]
 #![no_main]
 
-use aya_ebpf::{macros::socket_filter, programs::SkBuffContext};
+use aya_ebpf::{
+    macros::{map, socket_filter},
+    maps::HashMap,
+    programs::SkBuffContext,
+};
+use aya_log_ebpf::info;
+
+#[map(name = "BLOCK_LIST")]
+static mut BLOCK_LIST_MAP: HashMap<u32, u8> = HashMap::<u32, u8>::with_max_entries(1024, 0);
+
+#[map(name = "ALLOW_LIST")]
+static mut ALLOW_LIST_MAP: HashMap<u32, u8> = HashMap::<u32, u8>::with_max_entries(1024, 0);
 
 #[socket_filter]
-pub fn bee_trace(_ctx: SkBuffContext) -> i64 {
-    0
+pub fn bee_trace(ctx: SkBuffContext) -> i64 {
+    match unsafe { try_bee_trace(&ctx) } {
+        Ok(pass) => pass as i64,
+        Err(ret) => ret as i64,
+    }
+}
+
+unsafe fn try_bee_trace(ctx: &SkBuffContext) -> Result<u32, u32> {
+    let src = ctx.skb.remote_ipv4();
+    let dst = ctx.skb.local_ipv4();
+
+    if BLOCK_LIST_MAP.get(&src).is_some() || BLOCK_LIST_MAP.get(&dst).is_some() {
+        info!(ctx, "blocked {:i} -> {:i}", src, dst);
+        return Ok(0);
+    }
+
+    if ALLOW_LIST_MAP.get(&src).is_some() || ALLOW_LIST_MAP.get(&dst).is_some() {
+        info!(ctx, "allowed {:i} -> {:i}", src, dst);
+        return Ok(1);
+    }
+
+    Ok(1)
 }
 
 #[cfg(not(test))]

--- a/bee-trace/src/main.rs
+++ b/bee-trace/src/main.rs
@@ -1,7 +1,56 @@
-use aya::programs::SocketFilter;
+use aya::{maps::HashMap as AyaHashMap, programs::SocketFilter};
 #[rustfmt::skip]
 use log::{debug, warn};
-use tokio::signal;
+use std::{net::{Ipv4Addr, SocketAddr}, str::FromStr};
+use bee_trace_common::{ALLOW_LIST, BLOCK_LIST};
+use tokio::{net::lookup_host, signal};
+use anyhow::anyhow;
+
+async fn parse_address_list(list: &str) -> Vec<Ipv4Addr> {
+    let mut addrs = Vec::new();
+    for item in list.split(',') {
+        let item = item.trim();
+        if item.is_empty() {
+            continue;
+        }
+        if let Ok(ip) = Ipv4Addr::from_str(item) {
+            addrs.push(ip);
+            continue;
+        }
+        if let Ok(resolved) = lookup_host((item, 0)).await {
+            for addr in resolved {
+                if let SocketAddr::V4(v4) = addr {
+                    addrs.push(*v4.ip());
+                }
+            }
+        }
+    }
+    addrs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn parse_ip() {
+        let res = parse_address_list("127.0.0.1").await;
+        assert_eq!(res, vec![Ipv4Addr::new(127, 0, 0, 1)]);
+    }
+
+    #[tokio::test]
+    async fn parse_domain() {
+        let res = parse_address_list("localhost").await;
+        assert!(res.contains(&Ipv4Addr::new(127, 0, 0, 1)));
+    }
+
+    #[tokio::test]
+    async fn parse_multiple() {
+        let res = parse_address_list("127.0.0.1,localhost").await;
+        assert!(res.contains(&Ipv4Addr::new(127, 0, 0, 1)));
+        assert!(res.len() >= 1);
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -29,6 +78,25 @@ async fn main() -> anyhow::Result<()> {
     if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
         // This can happen if you remove all log statements from your eBPF program.
         warn!("failed to initialize eBPF logger: {e}");
+    }
+
+    let mut block_map = AyaHashMap::<_, u32, u8>::try_from(
+        ebpf.take_map(BLOCK_LIST).ok_or_else(|| anyhow!("map not found"))?,
+    )?;
+    let mut allow_map = AyaHashMap::<_, u32, u8>::try_from(
+        ebpf.take_map(ALLOW_LIST).ok_or_else(|| anyhow!("map not found"))?,
+    )?;
+
+    if let Ok(list) = std::env::var("BLOCK_LIST") {
+        for addr in parse_address_list(&list).await {
+            let _ = block_map.insert(u32::from(addr), 1, 0);
+        }
+    }
+
+    if let Ok(list) = std::env::var("ALLOW_LIST") {
+        for addr in parse_address_list(&list).await {
+            let _ = allow_map.insert(u32::from(addr), 1, 0);
+        }
     }
     let listener = std::net::TcpListener::bind("localhost:0")?;
     let prog: &mut SocketFilter = ebpf.program_mut("bee_trace").unwrap().try_into()?;


### PR DESCRIPTION
## Summary
- add block and allow list maps to the eBPF program
- allow hostnames in `BLOCK_LIST` and `ALLOW_LIST`
- parse comma-separated address lists when populating maps
- use dedicated variables for the maps

## Testing
- `cargo test -p bee-trace -p bee-trace-common`
- `cargo test --workspace`
- `cargo check -p bee-trace`
- `cargo check -p bee-trace-ebpf` *(fails: panic strategy unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_684b1e2f83d88323a7405ae6a992d8f5