### PR TITLE
refactor: Migrate CLI from clap builder to derive API

### DIFF
--- a/bee-trace/src/cli.rs
+++ b/bee-trace/src/cli.rs
@@ -1,313 +1,214 @@
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
-use clap::{Arg, ArgMatches, Command};
+use clap::{Parser, Subcommand};
 
 use crate::configuration::Configuration;
 
+#[derive(Parser)]
+#[command(name = "bee-trace")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(author = "bee-trace contributors")]
+#[command(about = "eBPF-based security monitoring and tracing tool")]
+#[command(
+    long_about = "bee-trace uses eBPF to monitor system activities including file access, network connections, memory operations, and secret access attempts."
+)]
 pub struct CliApp {
-    app: Command,
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
+    #[command(flatten)]
+    pub args: CliArgs,
 }
 
-impl CliApp {
-    pub fn new() -> Self {
-        let app = Command::new("bee-trace")
-            .version(env!("CARGO_PKG_VERSION"))
-            .author("bee-trace contributors")
-            .about("eBPF-based security monitoring and tracing tool")
-            .long_about("bee-trace uses eBPF to monitor system activities including file access, network connections, memory operations, and secret access attempts.")
-            .arg(
-                Arg::new("probe-type")
-                    .short('p')
-                    .long("probe-type")
-                    .value_name("TYPE")
-                    .help("Type of probe to attach")
-                    .long_help("Specify which eBPF probe to attach:\n\
-                               - file_monitor: Monitor file access and secret files\n\
-                               - network_monitor: Monitor network connections\n\
-                               - memory_monitor: Monitor process memory access\n\
-                               - all: Enable all monitoring capabilities")
-                    .value_parser(["file_monitor", "network_monitor", "memory_monitor", "all"])
-                    .default_value("file_monitor")
-            )
-            .arg(
-                Arg::new("duration")
-                    .short('d')
-                    .long("duration")
-                    .value_name("SECONDS")
-                    .help("Duration to run the tracer in seconds")
-                    .long_help("Specify how long to run the monitoring session. If not specified, runs until Ctrl+C is pressed.")
-                    .value_parser(clap::value_parser!(u64))
-            )
-            .arg(
-                Arg::new("command")
-                    .short('c')
-                    .long("command")
-                    .value_name("PATTERN")
-                    .help("Filter events by process name (substring match)")
-                    .long_help("Only show events from processes whose command name contains this pattern.")
-            )
-            .arg(
-                Arg::new("verbose")
-                    .short('v')
-                    .long("verbose")
-                    .help("Show verbose output including UIDs")
-                    .action(clap::ArgAction::SetTrue)
-            )
-            .arg(
-                Arg::new("security-mode")
-                    .long("security-mode")
-                    .help("Enable security monitoring mode with enhanced event classification")
-                    .action(clap::ArgAction::SetTrue)
-            )
-            .arg(
-                Arg::new("config")
-                    .long("config")
-                    .value_name("FILE")
-                    .help("Configuration file path")
-                    .long_help("Path to YAML configuration file for advanced settings.")
-                    .value_parser(clap::value_parser!(PathBuf))
-            )
-            .arg(
-                Arg::new("output")
-                    .short('o')
-                    .long("output")
-                    .value_name("FILE")
-                    .help("Output file for saving results")
-                    .long_help("Save monitoring results to a file. Supports JSON and Markdown formats based on file extension.")
-                    .value_parser(clap::value_parser!(PathBuf))
-            )
-            .arg(
-                Arg::new("format")
-                    .short('f')
-                    .long("format")
-                    .value_name("FORMAT")
-                    .help("Output format")
-                    .long_help("Format for saved output: json, markdown, or csv")
-                    .value_parser(["json", "markdown", "csv"])
-                    .default_value("json")
-            )
-            .arg(
-                Arg::new("filter-severity")
-                    .long("filter-severity")
-                    .value_name("LEVEL")
-                    .help("Only show events of specified severity or higher")
-                    .value_parser(["low", "medium", "high", "critical"])
-            )
-            .arg(
-                Arg::new("no-header")
-                    .long("no-header")
-                    .help("Suppress column headers in output")
-                    .action(clap::ArgAction::SetTrue)
-            )
-            .arg(
-                Arg::new("timestamp-format")
-                    .long("timestamp-format")
-                    .value_name("FORMAT")
-                    .help("Timestamp format for events")
-                    .value_parser(["unix", "iso8601", "relative"])
-                    .default_value("iso8601")
-            )
-            .subcommand(
-                Command::new("report")
-                    .about("Generate reports from saved monitoring data")
-                    .arg(
-                        Arg::new("input")
-                            .value_name("FILE")
-                            .help("Input file containing monitoring data")
-                            .required(true)
-                            .value_parser(clap::value_parser!(PathBuf))
-                    )
-                    .arg(
-                        Arg::new("format")
-                            .short('f')
-                            .long("format")
-                            .value_name("FORMAT")
-                            .help("Report format")
-                            .value_parser(["summary", "detailed", "json", "markdown"])
-                            .default_value("summary")
-                    )
-                    .arg(
-                        Arg::new("output")
-                            .short('o')
-                            .long("output")
-                            .value_name("FILE")
-                            .help("Output file for the report")
-                            .value_parser(clap::value_parser!(PathBuf))
-                    )
-            )
-            .subcommand(
-                Command::new("config")
-                    .about("Configuration management")
-                    .subcommand(
-                        Command::new("generate")
-                            .about("Generate a sample configuration file")
-                            .arg(
-                                Arg::new("output")
-                                    .short('o')
-                                    .long("output")
-                                    .value_name("FILE")
-                                    .help("Output configuration file path")
-                                    .default_value("bee-trace.yaml")
-                                    .value_parser(clap::value_parser!(PathBuf))
-                            )
-                    )
-                    .subcommand(
-                        Command::new("validate")
-                            .about("Validate a configuration file")
-                            .arg(
-                                Arg::new("config")
-                                    .value_name("FILE")
-                                    .help("Configuration file to validate")
-                                    .required(true)
-                                    .value_parser(clap::value_parser!(PathBuf))
-                            )
-                    )
-            );
+#[derive(Parser)]
+pub struct CliArgs {
+    /// Type of probe to attach
+    #[arg(short = 'p', long, value_enum, default_value = "file-monitor")]
+    #[arg(help = "Specify which eBPF probe to attach")]
+    pub probe_type: ProbeType,
 
-        Self { app }
-    }
+    /// Duration to run the tracer in seconds
+    #[arg(short = 'd', long)]
+    #[arg(
+        help = "Specify how long to run the monitoring session. If not specified, runs until Ctrl+C is pressed."
+    )]
+    pub duration: Option<u64>,
 
-    pub fn get_matches(self) -> ArgMatches {
-        self.app.get_matches()
-    }
+    /// Filter events by process name (substring match)
+    #[arg(short = 'c', long)]
+    #[arg(help = "Only show events from processes whose command name contains this pattern.")]
+    pub command: Option<String>,
 
-    pub fn try_get_matches(self) -> Result<ArgMatches, clap::Error> {
-        self.app.try_get_matches()
-    }
-}
-
-impl Default for CliApp {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-pub struct CliConfig {
-    pub probe_type: String,
-    pub duration: Option<Duration>,
-    pub command_filter: Option<String>,
+    /// Show verbose output including UIDs
+    #[arg(short = 'v', long)]
     pub verbose: bool,
+
+    /// Enable security monitoring mode with enhanced event classification
+    #[arg(long)]
     pub security_mode: bool,
-    pub config_file: Option<PathBuf>,
-    pub output_file: Option<PathBuf>,
-    pub output_format: String,
-    pub filter_severity: Option<String>,
+
+    /// Configuration file path
+    #[arg(long)]
+    #[arg(help = "Path to YAML configuration file for advanced settings.")]
+    pub config: Option<PathBuf>,
+
+    /// Output file for saving results
+    #[arg(short = 'o', long)]
+    #[arg(
+        help = "Save monitoring results to a file. Supports JSON and Markdown formats based on file extension."
+    )]
+    pub output: Option<PathBuf>,
+
+    /// Output format
+    #[arg(short = 'f', long, value_enum, default_value = "json")]
+    #[arg(help = "Format for saved output: json, markdown, or csv")]
+    pub format: OutputFormat,
+
+    /// Only show events of specified severity or higher
+    #[arg(long, value_enum)]
+    pub filter_severity: Option<SeverityLevel>,
+
+    /// Suppress column headers in output
+    #[arg(long)]
     pub no_header: bool,
-    pub timestamp_format: String,
+
+    /// Timestamp format for events
+    #[arg(long, value_enum, default_value = "iso8601")]
+    pub timestamp_format: TimestampFormat,
 }
 
-impl CliConfig {
-    pub fn from_matches(matches: &ArgMatches) -> anyhow::Result<Self> {
-        let probe_type = matches.get_one::<String>("probe-type").unwrap().clone();
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum ProbeType {
+    #[value(name = "file_monitor")]
+    FileMonitor,
+    #[value(name = "network_monitor")]
+    NetworkMonitor,
+    #[value(name = "memory_monitor")]
+    MemoryMonitor,
+    #[value(name = "all")]
+    All,
+}
 
-        let duration = matches
-            .get_one::<u64>("duration")
-            .map(|&d| Duration::from_secs(d));
-
-        let command_filter = matches.get_one::<String>("command").cloned();
-
-        let verbose = matches.get_flag("verbose");
-        let security_mode = matches.get_flag("security-mode");
-        let no_header = matches.get_flag("no-header");
-
-        let config_file = matches.get_one::<PathBuf>("config").cloned();
-
-        let output_file = matches.get_one::<PathBuf>("output").cloned();
-
-        let output_format = matches.get_one::<String>("format").unwrap().clone();
-
-        let filter_severity = matches.get_one::<String>("filter-severity").cloned();
-
-        let timestamp_format = matches
-            .get_one::<String>("timestamp-format")
-            .unwrap()
-            .clone();
-
-        Ok(Self {
-            probe_type,
-            duration,
-            command_filter,
-            verbose,
-            security_mode,
-            config_file,
-            output_file,
-            output_format,
-            filter_severity,
-            no_header,
-            timestamp_format,
-        })
+impl From<ProbeType> for Vec<crate::errors::ProbeType> {
+    fn from(cli_type: ProbeType) -> Self {
+        match cli_type {
+            ProbeType::FileMonitor => vec![crate::errors::ProbeType::FileMonitor],
+            ProbeType::NetworkMonitor => vec![crate::errors::ProbeType::NetworkMonitor],
+            ProbeType::MemoryMonitor => vec![crate::errors::ProbeType::MemoryMonitor],
+            ProbeType::All => crate::errors::ProbeType::all(),
+        }
     }
+}
 
-    pub fn merge_with_configuration(&mut self, config: &Configuration) -> anyhow::Result<()> {
-        // Merge monitoring settings
-        if self.duration.is_none() {
-            self.duration = config.monitoring.duration;
-        }
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum OutputFormat {
+    #[value(name = "json")]
+    Json,
+    #[value(name = "markdown")]
+    Markdown,
+    #[value(name = "csv")]
+    Csv,
+}
 
-        if !self.verbose {
-            self.verbose = config.output.verbose;
-        }
+#[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
+pub enum SeverityLevel {
+    #[value(name = "low")]
+    Low,
+    #[value(name = "medium")]
+    Medium,
+    #[value(name = "high")]
+    High,
+    #[value(name = "critical")]
+    Critical,
+}
 
-        if !self.security_mode {
-            self.security_mode = config.monitoring.security_mode;
-        }
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum TimestampFormat {
+    #[value(name = "unix")]
+    Unix,
+    #[value(name = "iso8601")]
+    Iso8601,
+    #[value(name = "relative")]
+    Relative,
+}
 
-        // Merge output settings - removed unused fields (no_header, output_file, format, timestamp_format)
-        // and may need conversion from the enum types in Configuration
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Generate reports from saved monitoring data
+    Report {
+        /// Input file containing monitoring data
+        input: PathBuf,
+        /// Report format
+        #[arg(short = 'f', long, value_enum, default_value = "summary")]
+        format: ReportFormat,
+        /// Output file for the report
+        #[arg(short = 'o', long)]
+        output: Option<PathBuf>,
+    },
+    /// Configuration management
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+}
 
-        Ok(())
-    }
+#[derive(Subcommand)]
+pub enum ConfigCommand {
+    /// Generate a sample configuration file
+    Generate {
+        /// Output configuration file path
+        #[arg(short = 'o', long, default_value = "bee-trace.yaml")]
+        output: PathBuf,
+    },
+    /// Validate a configuration file
+    Validate {
+        /// Configuration file to validate
+        config: PathBuf,
+    },
+}
 
-    pub fn validate(&self) -> anyhow::Result<()> {
-        let valid_probe_types = ["file_monitor", "network_monitor", "memory_monitor", "all"];
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum ReportFormat {
+    #[value(name = "summary")]
+    Summary,
+    #[value(name = "detailed")]
+    Detailed,
+    #[value(name = "json")]
+    Json,
+    #[value(name = "markdown")]
+    Markdown,
+}
 
-        if !valid_probe_types.contains(&self.probe_type.as_str()) {
-            return Err(anyhow::anyhow!("Invalid probe type: {}", self.probe_type));
-        }
-
-        if let Some(severity) = &self.filter_severity {
-            let valid_severities = ["low", "medium", "high", "critical"];
-            if !valid_severities.contains(&severity.as_str()) {
-                return Err(anyhow::anyhow!("Invalid severity filter: {}", severity));
-            }
-        }
-
-        let valid_formats = ["json", "markdown", "csv"];
-        if !valid_formats.contains(&self.output_format.as_str()) {
-            return Err(anyhow::anyhow!(
-                "Invalid output format: {}. Valid formats: {:?}",
-                self.output_format,
-                valid_formats
-            ));
-        }
-
-        let valid_timestamp_formats = ["unix", "iso8601", "relative"];
-        if !valid_timestamp_formats.contains(&self.timestamp_format.as_str()) {
-            return Err(anyhow::anyhow!(
-                "Invalid timestamp format: {}. Valid formats: {:?}",
-                self.timestamp_format,
-                valid_timestamp_formats
-            ));
-        }
-
-        Ok(())
-    }
-
-    pub fn should_show_severity(&self, severity: &str) -> bool {
+impl CliArgs {
+    pub fn should_show_severity(&self, severity: &SeverityLevel) -> bool {
         if let Some(min_severity) = &self.filter_severity {
-            let severity_levels = ["low", "medium", "high", "critical"];
+            let severity_levels = [
+                SeverityLevel::Low,
+                SeverityLevel::Medium,
+                SeverityLevel::High,
+                SeverityLevel::Critical,
+            ];
             let min_index = severity_levels
                 .iter()
-                .position(|&s| s == min_severity)
+                .position(|s| s == min_severity)
                 .unwrap_or(0);
             let event_index = severity_levels
                 .iter()
-                .position(|&s| s == severity)
+                .position(|s| s == severity)
                 .unwrap_or(0);
             return event_index >= min_index;
         }
         true
     }
+}
+
+/// Create configuration directly from CLI arguments
+pub fn create_configuration_from_cli_args(args: &CliArgs) -> Result<Configuration, anyhow::Error> {
+    crate::configuration::ConfigurationBuilder::new()
+        .from_cli_args_typed(args)
+        .map_err(|e| anyhow::anyhow!("Failed to parse CLI arguments: {}", e))?
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build configuration: {}", e))
 }
 
 pub fn print_banner() {
@@ -340,110 +241,81 @@ pub fn print_usage_examples() {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn should_create_cli_app() {
-        let app = CliApp::new();
-        assert_eq!(app.app.get_name(), "bee-trace");
-    }
+    use clap::Parser;
 
     #[test]
     fn should_parse_basic_args() {
-        let app = CliApp::new();
-        let matches = app
-            .app
-            .try_get_matches_from(vec!["bee-trace", "--probe-type", "file_monitor"])
-            .unwrap();
-
-        let config = CliConfig::from_matches(&matches).unwrap();
-        assert_eq!(config.probe_type, "file_monitor");
-        assert!(!config.verbose);
-        assert!(!config.security_mode);
+        let args =
+            CliApp::try_parse_from(vec!["bee-trace", "--probe-type", "file_monitor"]).unwrap();
+        assert!(matches!(args.args.probe_type, ProbeType::FileMonitor));
+        assert!(!args.args.verbose);
+        assert!(!args.args.security_mode);
     }
 
     #[test]
     fn should_parse_complex_args() {
-        let app = CliApp::new();
-        let matches = app
-            .app
-            .try_get_matches_from(vec![
-                "bee-trace",
-                "--probe-type",
-                "network_monitor",
-                "--duration",
-                "30",
-                "--command",
-                "nginx",
-                "--verbose",
-                "--security-mode",
-            ])
-            .unwrap();
+        let args = CliApp::try_parse_from(vec![
+            "bee-trace",
+            "--probe-type",
+            "network_monitor",
+            "--duration",
+            "30",
+            "--command",
+            "nginx",
+            "--verbose",
+            "--security-mode",
+        ])
+        .unwrap();
 
-        let config = CliConfig::from_matches(&matches).unwrap();
-        assert_eq!(config.probe_type, "network_monitor");
-        assert_eq!(config.duration, Some(Duration::from_secs(30)));
-        assert_eq!(config.command_filter, Some("nginx".to_string()));
-        assert!(config.verbose);
-        assert!(config.security_mode);
-    }
-
-    #[test]
-    fn should_validate_probe_types() {
-        let config = CliConfig {
-            probe_type: "invalid_probe".to_string(),
-            duration: None,
-            command_filter: None,
-            verbose: false,
-            security_mode: false,
-            config_file: None,
-            output_file: None,
-            output_format: "json".to_string(),
-            filter_severity: None,
-            no_header: false,
-            timestamp_format: "iso8601".to_string(),
-        };
-
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn should_validate_severity_filters() {
-        let config = CliConfig {
-            probe_type: "file_monitor".to_string(),
-            duration: None,
-            command_filter: None,
-            verbose: false,
-            security_mode: false,
-            config_file: None,
-            output_file: None,
-            output_format: "json".to_string(),
-            filter_severity: Some("invalid".to_string()),
-            no_header: false,
-            timestamp_format: "iso8601".to_string(),
-        };
-
-        assert!(config.validate().is_err());
+        assert!(matches!(args.args.probe_type, ProbeType::NetworkMonitor));
+        assert_eq!(args.args.duration, Some(30));
+        assert_eq!(args.args.command, Some("nginx".to_string()));
+        assert!(args.args.verbose);
+        assert!(args.args.security_mode);
     }
 
     #[test]
     fn should_filter_severity_correctly() {
-        let config = CliConfig {
-            probe_type: "file_monitor".to_string(),
+        let args = CliArgs {
+            probe_type: ProbeType::FileMonitor,
             duration: None,
-            command_filter: None,
+            command: None,
             verbose: false,
             security_mode: false,
-            config_file: None,
-            output_file: None,
-            output_format: "json".to_string(),
-            filter_severity: Some("medium".to_string()),
+            config: None,
+            output: None,
+            format: OutputFormat::Json,
+            filter_severity: Some(SeverityLevel::Medium),
             no_header: false,
-            timestamp_format: "iso8601".to_string(),
+            timestamp_format: TimestampFormat::Iso8601,
         };
 
-        assert!(!config.should_show_severity("low"));
-        assert!(config.should_show_severity("medium"));
-        assert!(config.should_show_severity("high"));
-        assert!(config.should_show_severity("critical"));
+        assert!(!args.should_show_severity(&SeverityLevel::Low));
+        assert!(args.should_show_severity(&SeverityLevel::Medium));
+        assert!(args.should_show_severity(&SeverityLevel::High));
+        assert!(args.should_show_severity(&SeverityLevel::Critical));
+    }
+
+    #[test]
+    fn should_create_configuration_from_cli_args() {
+        let args = CliArgs {
+            probe_type: ProbeType::All,
+            duration: Some(60),
+            command: Some("test".to_string()),
+            verbose: true,
+            security_mode: true,
+            config: None,
+            output: None,
+            format: OutputFormat::Json,
+            filter_severity: None,
+            no_header: false,
+            timestamp_format: TimestampFormat::Iso8601,
+        };
+
+        let config = create_configuration_from_cli_args(&args).unwrap();
+        assert_eq!(config.duration_secs(), Some(60));
+        assert_eq!(config.command_filter(), Some("test"));
+        assert!(config.is_verbose());
+        assert!(config.is_security_mode());
     }
 }

--- a/bee-trace/src/configuration/builder.rs
+++ b/bee-trace/src/configuration/builder.rs
@@ -30,6 +30,69 @@ impl ConfigurationBuilder {
         }
     }
 
+    /// Configure from typed CLI arguments (preferred method)
+    pub fn from_cli_args_typed(
+        mut self,
+        args: &crate::cli::CliArgs,
+    ) -> Result<Self, BeeTraceError> {
+        // Convert CLI enum to configuration enum using From trait
+        self.monitoring.probe_types = args.probe_type.clone().into();
+
+        // Set duration
+        if let Some(duration_secs) = args.duration {
+            self.monitoring.duration = Some(Duration::from_secs(duration_secs));
+        }
+
+        // Set command filter
+        self.monitoring.command_filter = args.command.clone();
+
+        // Set boolean flags
+        self.monitoring.security_mode = args.security_mode;
+        self.output.verbose = args.verbose;
+
+        Ok(self)
+    }
+
+    /// Configure from clap ArgMatches
+    pub fn from_arg_matches(mut self, matches: &clap::ArgMatches) -> Result<Self, BeeTraceError> {
+        // Extract probe type
+        if let Some(probe_type) = matches.get_one::<String>("probe-type") {
+            match probe_type.as_str() {
+                "file_monitor" => self.monitoring.probe_types = vec![ProbeType::FileMonitor],
+                "network_monitor" => self.monitoring.probe_types = vec![ProbeType::NetworkMonitor],
+                "memory_monitor" => self.monitoring.probe_types = vec![ProbeType::MemoryMonitor],
+                "all" => self.monitoring.probe_types = ProbeType::all(),
+                _ => {
+                    return Err(BeeTraceError::InvalidProbeType {
+                        probe_type: probe_type.clone(),
+                        valid_types: vec![
+                            "file_monitor".to_string(),
+                            "network_monitor".to_string(),
+                            "memory_monitor".to_string(),
+                            "all".to_string(),
+                        ],
+                    })
+                }
+            }
+        }
+
+        // Extract duration
+        if let Some(&duration_secs) = matches.get_one::<u64>("duration") {
+            self.monitoring.duration = Some(Duration::from_secs(duration_secs));
+        }
+
+        // Extract command filter
+        if let Some(command) = matches.get_one::<String>("command") {
+            self.monitoring.command_filter = Some(command.clone());
+        }
+
+        // Extract boolean flags
+        self.output.verbose = matches.get_flag("verbose");
+        self.monitoring.security_mode = matches.get_flag("security-mode");
+
+        Ok(self)
+    }
+
     /// Configure from CLI arguments (Vec<String> format for testing)
     pub fn from_cli_args(mut self, args: &[&str]) -> Result<Self, BeeTraceError> {
         let mut i = 0;


### PR DESCRIPTION
Replace legacy clap::Command builder pattern with modern derive-based approach for improved type safety and maintainability. Updates include:

- Convert CliApp to derive-based clap::Parser with structured arguments
- Replace string-based configuration with typed enums (ProbeType, OutputFormat, SeverityLevel)
- Simplify CLI argument parsing with automatic validation
- Add From trait implementation for ProbeType conversion
- Update ConfigurationBuilder with typed CLI integration
- Modernize test suite to use derive-based parsing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
