### PR TITLE
Add eBPF execution integration test crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bee-trace-exec-test"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aya",
+ "bee-trace",
+ "bee-trace-common",
+ "bytes",
+ "libc",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "bee-trace-common",
     "bee-trace-ebpf",
     "bee-trace-bindings",
+    "bee-trace-exec-test",
 ]
 default-members = ["bee-trace", "bee-trace-common"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,13 @@ RUN --mount=type=bind,source=bee-trace,target=bee-trace \
     --mount=type=bind,source=bee-trace-common,target=bee-trace-common \
     --mount=type=bind,source=bee-trace-ebpf,target=bee-trace-ebpf \
     --mount=type=bind,source=bee-trace-bindings,target=bee-trace-bindings \
+    --mount=type=bind,source=bee-trace-exec-test,target=bee-trace-exec-test \
     --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=cache,target=/app/target/ \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     <<EOF
 set -e
-RUST_BACKTRACE=1 cargo build --release
+RUST_BACKTRACE=1 cargo build --release -p bee-trace
 cp ./target/release/$APP_NAME /bin/myapp
 EOF
 

--- a/bee-trace-exec-test/Cargo.toml
+++ b/bee-trace-exec-test/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bee-trace-exec-test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+bee-trace = { path = "../bee-trace" }
+bee-trace-common = { path = "../bee-trace-common", features = ["user"] }
+aya = { workspace = true }
+bytes = "1.0"
+anyhow = { workspace = true, default-features = true }
+libc = { workspace = true }

--- a/bee-trace-exec-test/README.md
+++ b/bee-trace-exec-test/README.md
@@ -1,0 +1,14 @@
+# bee-trace-exec-test
+
+Integration test crate that exercises the `bee-trace` eBPF programs end to end.
+The provided test loads and attaches the file-monitor program and verifies that
+access to a `.env` file is reported through the perf buffer.
+
+> **Note**
+> The test requires root privileges to attach eBPF programs. When run without
+> sufficient permission, it will skip automatically.
+>
+> ```bash
+> cargo test -p bee-trace-exec-test -- --nocapture
+> ```
+

--- a/bee-trace-exec-test/src/lib.rs
+++ b/bee-trace-exec-test/src/lib.rs
@@ -1,0 +1,1 @@
+// Empty lib to satisfy cargo for test crate

--- a/bee-trace-exec-test/tests/ebpf_execution.rs
+++ b/bee-trace-exec-test/tests/ebpf_execution.rs
@@ -1,0 +1,87 @@
+use std::{fs::File, path::PathBuf, time::Duration};
+
+use aya::{maps::PerfEventArray, util::online_cpus, Ebpf};
+use bee_trace::ebpf_manager::{FileProbeManager, ProbeManager};
+use bee_trace::errors::ProbeType;
+use bee_trace_common::SecretAccessEvent;
+use bytes::BytesMut;
+use libc;
+
+fn load_ebpf() -> anyhow::Result<Ebpf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
+    let build_dir = manifest_dir
+        .parent()
+        .expect("workspace root")
+        .join("target")
+        .join(&profile)
+        .join("build");
+    for entry in std::fs::read_dir(build_dir)? {
+        let entry = entry?;
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with("bee-trace-")
+        {
+            let candidate = entry
+                .path()
+                .join("out/bee-trace-ebpf/bpfel-unknown-none/release/bee-trace");
+            if candidate.exists() {
+                let data = std::fs::read(candidate)?;
+                return Ok(Ebpf::load(&data)?);
+            }
+        }
+    }
+    Err(anyhow::anyhow!("eBPF object not found"))
+}
+
+#[test]
+fn should_capture_secret_file_access_event() -> anyhow::Result<()> {
+    if unsafe { libc::geteuid() } != 0 {
+        eprintln!("skipping test, requires root privileges");
+        return Ok(());
+    }
+
+    let rlim = libc::rlimit { rlim_cur: libc::RLIM_INFINITY, rlim_max: libc::RLIM_INFINITY };
+    unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
+
+    let mut ebpf = load_ebpf()?;
+
+    let mut manager = FileProbeManager::new();
+    if let Err(e) = manager.attach(&mut ebpf, ProbeType::FileMonitor) {
+        eprintln!("skipping test, failed to attach BPF program: {e}");
+        return Ok(());
+    }
+
+    let mut perf_array: PerfEventArray<_> = ebpf
+        .take_map("SECRET_ACCESS_EVENTS")
+        .expect("map not found")
+        .try_into()?;
+
+    let mut buffers = Vec::new();
+    for cpu in online_cpus().map_err(|e| anyhow::anyhow!("{:?}", e))? {
+        buffers.push(perf_array.open(cpu, None)?);
+    }
+
+    let file_path = std::env::temp_dir().join(".env_test");
+    std::fs::write(&file_path, b"KEY=VALUE")?;
+    let _file = File::open(&file_path)?;
+
+    std::thread::sleep(Duration::from_millis(100));
+
+    let mut found = false;
+    for buf in &mut buffers {
+        let mut v = [BytesMut::with_capacity(1024)];
+        if let Ok(events) = buf.read_events(&mut v) {
+            for data in v.iter().take(events.read) {
+                let event = unsafe { data.as_ptr().cast::<SecretAccessEvent>().read_unaligned() };
+                if event.path_or_var_as_str().ends_with(".env_test") {
+                    found = true;
+                }
+            }
+        }
+    }
+
+    assert!(found, "no secret access event captured for .env_test file");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add new `bee-trace-exec-test` workspace member for running eBPF execution tests
- implement integration test that loads and attaches the file-monitor eBPF program and verifies secret access events
- document root privilege requirement and mark test crate as non-publish

## Testing
- `cargo test -p bee-trace-exec-test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68b1af9bc1848323806748db5a6e2f21